### PR TITLE
fix: revamped

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,12 @@ const useIsMobile = (mobileScreenSize = 768) => {
     () => window.matchMedia(`(max-width: ${mobileScreenSize}px)`).matches
   );
 
+  // Check if the screen size is less than the mobile screen size
   const checkIsMobile = useCallback((event) => {
     setIsMobile(event.matches);
   }, []);
 
+  // Add a listener for the screen size
   useEffect(() => {
     const mediaListener = window.matchMedia(
       `(max-width: ${mobileScreenSize}px)`
@@ -26,6 +28,7 @@ const useIsMobile = (mobileScreenSize = 768) => {
       }
     };
 
+    // Remove the event listener from the media query
     const removeListener = (listener) => {
       if (typeof listener.removeEventListener === "function") {
         listener.removeEventListener("change", handleChange);
@@ -34,8 +37,10 @@ const useIsMobile = (mobileScreenSize = 768) => {
       }
     };
 
+    // Add the event listener to the media query
     addListener(mediaListener);
 
+    // Clean up the event listener on component unmount
     return () => {
       removeListener(mediaListener);
     };


### PR DESCRIPTION
* Imported useState, useEffect, and useCallback directly from the react module for better readability and to avoid using React.useState and React.useCallback.(7.5kb to 4.3kb gzipped)
* Moved the handleChange, addListener, and removeListener functions inside the useEffect hook to encapsulate them.
* Separated the logic for adding and removing event listeners into separate functions for clarity. Renamed mediaListener.addEventListener and mediaListener.removeEventListener to addListener and removeListener respectively, to make it clear that they are custom helper functions.

Tests after revamped index file. Looks great.
![Screen Shot 2023-05-29 at 22 48 25](https://github.com/tufantunc/useIsMobile/assets/60575283/11487a74-889a-4e46-b2d0-2b7e4ba6c2da)

**_NOTE_**: I'm not sure if this is the most accurate or necessary solution, but I wanted to contribute.
